### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,18 +2,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-NTPClient         KEYWORD1
-Timezone          KEYWORD1
+NTPClient	KEYWORD1
+Timezone	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin             KEYWORD2
-update            KEYWORD2
-forceUpdate       KEYWORD2
-getHours          KEYWORD2
-getMinutes        KEYWORD2
-getSeconds        KEYWORD2
-getFormattedTime  KEYWORD2
-getRawTime        KEYWORD2
+begin	KEYWORD2
+update	KEYWORD2
+forceUpdate	KEYWORD2
+getHours	KEYWORD2
+getMinutes	KEYWORD2
+getSeconds	KEYWORD2
+getFormattedTime	KEYWORD2
+getRawTime	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords